### PR TITLE
Edit broader/narrower and derived periods

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "eslint:recommended",
   "parserOptions": {
-    "ecmaVersion": 2017
+    "ecmaVersion": 2018
   },
   "env": {
     "node": true,

--- a/Makefile
+++ b/Makefile
@@ -78,8 +78,8 @@ $(VERSIONED_DIRECTORY)/package.json: package.json
 	jq '{ name, version, author, contributors, license, description }' $< > $@
 
 $(VERSIONED_ZIPFILE): $(ZIPPED_FILES) | dist
-	rm -f $@
-	mkdir -p $(VERSIONED_DIRECTORY)
+	rm -rf $@ $(VERSIONED_DIRECTORY)
+	mkdir $(VERSIONED_DIRECTORY)
 	cp $^ $(VERSIONED_DIRECTORY)
 	cd $(VERSIONED_DIRECTORY) && mkdir images && mv $(notdir $(ASSET_FILES)) images
 	jq '{ name, version, author, contributors, license, description, repository, bugs }' package.json > $(VERSIONED_DIRECTORY)/package.json

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ clean:
 
 publish: clean zip
 	unzip $(VERSIONED_ZIPFILE) -d dist
-	cd $(VERSIONED_DIRECTORY) && npm publish --dry-run
+	cd $(VERSIONED_DIRECTORY) && npm publish
 
 .PHONY: all watch zip serve test clean
 

--- a/modules/periodo-app/src/backends/components/PeriodAddOrEdit.js
+++ b/modules/periodo-app/src/backends/components/PeriodAddOrEdit.js
@@ -9,26 +9,24 @@ const h = require('react-hyperscript')
     , PeriodForm = require('../../forms/PeriodForm')
     , { LocationStreamAware, Route } = require('org-shell')
 
-// FIXME: this assumes that narrower periods are always from the
-// same authority; this could possibly change in the future.
-const findNarrower = (periodID, authority) => Object.values(authority.periods)
-  .reduce((narrower, period) => period.broader === periodID
-    ? narrower.concat(period.id)
-    : narrower, []
-)
+const emptyPeriod = () => ({
+  [Symbol.for('RelatedPeriods')]: {
+    derivedFrom: {},
+    broader: {},
+    narrower: {}
+  }
+})
 
 class AddPeriod extends React.Component {
   constructor(props) {
     super(props);
 
-    const period = props.period || {}
+    const period = props.period || emptyPeriod()
 
-    // to be modified during editing
-    period.narrower = period.id
-      ? findNarrower(period.id, props.authority)
-      : []
+    // to be edited
+    period.narrower = R.keys(period[Symbol.for('RelatedPeriods')].narrower)
 
-    // for comparison after editing is finished
+    // for comparison at save
     const narrower = R.clone(period.narrower)
 
     this.state = { period, narrower }

--- a/modules/periodo-app/src/backends/components/PeriodAddOrEdit.js
+++ b/modules/periodo-app/src/backends/components/PeriodAddOrEdit.js
@@ -29,7 +29,7 @@ class AddPeriod extends React.Component {
 
     this.state = {
       period,
-      related: period[$$RelatedPeriods]
+      related: R.clone(period[$$RelatedPeriods])
     }
   }
 

--- a/modules/periodo-app/src/backends/components/PeriodView.js
+++ b/modules/periodo-app/src/backends/components/PeriodView.js
@@ -2,9 +2,10 @@
 
 const h = require('react-hyperscript')
     , { Box } = require('periodo-ui')
-    , { Period } = require('periodo-ui')
+    , { BackendContext, Period } = require('periodo-ui')
 
-module.exports = ({ period }) =>
-  h(Box, [
+module.exports = ({ period, backend }) => h(Box, [
+  h(BackendContext.Provider, { value: backend }, [
     h(Period, { value: period }),
   ])
+])

--- a/modules/periodo-app/src/backends/reducer.js
+++ b/modules/periodo-app/src/backends/reducer.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const R = require('ramda')
+    , { valueAsArray } = require('periodo-utils')
     , { $$Authority } = require('periodo-utils/src/symbols')
     , BackendAction = require('./actions')
 
@@ -15,7 +16,13 @@ const updateBackend = (backend, dataset, state) => {
 
   return R.pipe(
     R.set(R.lensPath(['available', identifier]), backend),
-    R.set(R.lensPath(['datasets', identifier]), addAuthoritySymbols(dataset))
+    R.set(
+      R.lensPath(['datasets', identifier]),
+      R.pipe(
+        addAuthoritySymbols,
+        addRelatedPeriodsSymbols,
+      )(dataset)
+    )
   )(state)
 }
 
@@ -26,6 +33,56 @@ function addAuthoritySymbols(dataset) {
       R.over(
         R.lensProp('periods'),
         R.map(R.assoc($$Authority, authority)),
+        authority
+      )
+    ),
+    dataset
+  )
+}
+
+// FIXME: this assumes that narrower periods are always from the
+// same authority; this could possibly change in the future.
+const narrowerPeriodIDs = (authority, periodID) => R.values(authority.periods)
+  .reduce((narrower, period) => period.broader === periodID
+    ? narrower.concat(period.id)
+    : narrower, [])
+
+const relatedPeriods = (dataset, authority, period) => {
+
+  const props = ['derivedFrom', 'broader', 'narrower']
+
+  const ids = R.fromPairs(
+    R.map(prop => [ prop, valueAsArray(prop, period) ], props)
+  )
+  const periods = R.fromPairs(R.map(prop => [ prop, {} ], props))
+
+  ids.narrower = narrowerPeriodIDs(authority, period.id)
+
+  const done = () => R.all(
+    prop => R.keys(periods[prop]).length === ids[prop].length,
+    props
+  )
+
+  for (const auth of [ authority, ...R.values(dataset.authorities) ]) {
+    for (const prop of props) {
+      periods[prop] = R.merge(periods[prop], R.pick(ids[prop], auth.periods))
+    }
+    if (done()) { break }
+  }
+  return periods
+}
+
+function addRelatedPeriodsSymbols(dataset) {
+  return R.over(
+    R.lensProp('authorities'),
+    R.map(authority =>
+      R.over(
+        R.lensProp('periods'),
+        R.map(period => {
+          period[Symbol.for('RelatedPeriods')] = relatedPeriods(
+            dataset, authority, period)
+          return period
+        }),
         authority
       )
     ),

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -137,7 +137,6 @@ const RelatedPeriodList = ({
   suggestionFilter=() => true,
   limit,
   authorities,
-  backendID,
   onValueChange,
   randomID,
   ...props
@@ -162,7 +161,7 @@ const RelatedPeriodList = ({
               ),
               ...(atLimit ? {} : { borderBottom: '1px dotted #ced4da' }),
             }, [
-                h(RelatedPeriod, { period, backendID })
+                h(RelatedPeriod, { period })
               ]
             )
           )

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -5,8 +5,8 @@ const h = require('react-hyperscript')
     , { useContext } = require('react')
     , { Route } = require('org-shell')
     , { RandomID } = require('periodo-common')
-    , { Flex, Box, Link, Text, Label, Autosuggest } = require('periodo-ui')
-    , { BackendContext } = require('periodo-ui')
+    , { Flex, Box, Link, Text, Label, Span } = require('periodo-ui')
+    , { Autosuggest, BackendContext } = require('periodo-ui')
     , util = require('periodo-utils')
 
 const spatialCoverageOf = period => period.spatialCoverageDescription
@@ -79,10 +79,9 @@ const renderSectionTitle = section =>
     section.title
   ])
 
-const renderSuggestion = (item, { isHighlighted }) => h(Box,
+const renderSuggestion = (item, { isHighlighted, isSelected }) => h(Box,
   Object.assign({
-    pl: 3,
-    pr: 1,
+    px: 1,
     py: '6px',
     border: 1,
     borderColor: 'transparent',
@@ -91,6 +90,11 @@ const renderSuggestion = (item, { isHighlighted }) => h(Box,
       cursor: 'pointer'
     },
   }, isHighlighted && { bg: 'gray.2' }), [
+    h(Span, {
+      display: 'inline-block',
+      width: '1em',
+      color: 'gray.6',
+    }, isSelected ? '✓' : ' '),
     item.name
   ]
 )
@@ -145,6 +149,8 @@ const RelatedPeriodList = ({
 
   const atLimit = limit && periods.length >= limit
 
+  const isSelected = item => R.any(period => period.id === item.id, periods)
+
   return h(Box, { css: { position: 'relative' }, ...props }, [
     h(Label, { htmlFor: randomID(name) }, label),
 
@@ -192,14 +198,19 @@ const RelatedPeriodList = ({
           multiSection: true,
           getSuggestions: getSuggestions(authorities, suggestionFilter),
           renderSectionTitle,
-          renderSuggestion,
+          renderSuggestion: (item, info) => renderSuggestion(
+            item, { isSelected: isSelected(item), ...info }
+          ),
           getSectionSuggestions: section => section.suggestions,
           inputProps: {
             placeholder: 'Begin typing to search for periods to add',
             id: randomID(name),
             borderRadius: '0 0 2px 2px'
           },
-          onSelect: period => onValueChange(periods.concat(period))
+          onSelect: item => onValueChange(isSelected(item)
+            ? periods.filter(({ id }) => id !== item.id)
+            : periods.concat(item)
+          )
         })
   ])
 }

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -100,12 +100,13 @@ const RelatedPeriod = ({
   ...props
 }) => {
 
+  const backend = useContext(BackendContext)
   const authority = util.period.authorityOf(period)
 
   return h(Box, props, [
     h(Link, {
       route: Route('period-view', {
-        backendID: useContext(BackendContext).asIdentifier(),
+        backendID: backend.asIdentifier(),
         authorityID: authority.id,
         periodID: period.id,
       })

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -1,0 +1,225 @@
+"use strict";
+
+const h = require('react-hyperscript')
+    , R = require('ramda')
+    , { Route } = require('org-shell')
+    , { RandomID } = require('periodo-common')
+    , { Flex, Box, Link, Text, Label } = require('periodo-ui')
+    , { Autosuggest } = require('periodo-ui')
+    , util = require('periodo-utils')
+
+const spatialCoverageOf = period => period.spatialCoverageDescription
+  ? period.spatialCoverageDescription
+  : period.spatialCoverage
+    ? period.spatialCoverage.map(place => place.label).join(', ')
+    : 'unknown'
+
+const temporalCoverageOf = period => `${
+  period.start.label || util.terminus.asString(period.start)
+} to ${
+  period.stop.label || util.terminus.asString(period.stop)
+}`
+
+const escapeRegexCharacters = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+const matcher = query => {
+  const escapedQuery = escapeRegexCharacters(query.trim())
+  if (escapedQuery === '') {
+     // match everything on empty query
+    return () => true
+  }
+  // match at beginnings of words
+  const regex = new RegExp("(^|[\\s&'()-/:´-]+)" + escapedQuery, 'i')
+  return s => regex.test(s)
+}
+
+const matches = query => {
+  const matches = matcher(query)
+
+  return (matched, period) => {
+    if (! period) {
+      return matched
+    }
+    for (const { label } of util.period.allLabels(period)) {
+      if (matches(label)) {
+        return matched.concat({
+          ...period,
+          name: `${label} (${spatialCoverageOf(period)})`
+        })
+      }
+    }
+    return matched
+  }
+}
+
+const getSuggestions = (authorities, suggestionFilter) => (query = '') => (
+  authorities
+    .map(authority => ({
+      title: util.authority.displayTitle(authority),
+      suggestions: Object.values(authority.periods)
+        .reduce(matches(query), [])
+        .filter(suggestionFilter)
+        //.filter(({ id }) => ! excludePeriodIDs.includes(id))
+    }))
+    .filter(section => section.suggestions.length > 0)
+)
+
+const renderSectionTitle = section =>
+  h(Box, {
+    px: 1,
+    py: '6px',
+    border: 1,
+    borderColor: 'transparent',
+    fontWeight: 'bold',
+    css: {borderRadius: 1}
+  }, [
+    section.title
+  ])
+
+const renderSuggestion = (item, { isHighlighted }) => h(Box,
+  Object.assign({
+    pl: 3,
+    pr: 1,
+    py: '6px',
+    border: 1,
+    borderColor: 'transparent',
+    css: {
+      borderRadius: 1,
+      cursor: 'pointer'
+    },
+  }, isHighlighted && { bg: 'gray.2' }), [
+    item.name
+  ]
+)
+
+const RelatedPeriod = ({
+  period,
+  backendID,
+  ...props
+}) => {
+
+  const authority = util.period.authorityOf(period)
+
+  return h(Box, props, [
+    h(Link, {
+      route: Route('period-view', {
+        backendID,
+        authorityID: authority.id,
+        periodID: period.id,
+      })
+    }, util.period.originalLabel(period).label),
+    h(Text, `${spatialCoverageOf(period)}, ${temporalCoverageOf(period)}`),
+    h(Text, util.authority.displayTitle(authority))
+  ])
+}
+
+const Deletable = ({ children, onDelete, ...props }) => h(Flex, {
+  ...props
+}, [
+  h(Box, {
+    flex: '0 0',
+    mr: 2,
+    color: 'gray.6',
+    style: { cursor: 'pointer' },
+    onClick: () => onDelete(),
+  }, '✕'),
+
+  h(Box, { flex: '1 1' }, children)
+])
+
+const getPeriods = (authorities, periodIDs) => {
+  if (! periodIDs) {
+    return []
+  }
+  if (! Array.isArray(periodIDs)) {
+    periodIDs = [ periodIDs ]
+  }
+  let periods = {}
+  for (const authority of authorities) {
+    periods = { ...R.pick(periodIDs, authority.periods) }
+    if (Object.keys(periods).length === periodIDs.length) {
+      break
+    }
+  }
+  return Object.values(periods).sort(R.comparator((a, b) => (
+    util.terminus.earliestYear(a.start) <  util.terminus.earliestYear(b.start)
+  )))
+}
+
+const RelatedPeriodList = ({
+  name,
+  label,
+  helpText,
+  periodIDs,
+  suggestionFilter=() => true,
+  limit,
+  authorities,
+  backendID,
+  onValueChange,
+  randomID,
+  ...props
+}) => {
+
+  const periods = getPeriods(authorities, periodIDs)
+      , atLimit = limit && periods.length >= limit
+
+  return h(Box, { css: { position: 'relative' }, ...props }, [
+    h(Label, { htmlFor: randomID(name) }, label),
+
+    helpText && h(Text, { size: 1, mb: 1 }, helpText),
+
+    h(Box, { mt: -1, mb: '-1px' }, [
+      periods.length
+        ? periods.map(
+            (period, key) => h(Deletable, {
+              key,
+              px: 1,
+              py: 2,
+              onDelete: () => onValueChange(
+                periods.filter(({ id }) => id !== period.id)
+              ),
+              ...(atLimit ? {} : { borderBottom: '1px dotted #ced4da' }),
+            }, [
+                h(RelatedPeriod, { period, backendID })
+              ]
+            )
+          )
+        : h(Box, {
+            py: 2,
+            color: 'gray.6',
+            css: { fontStyle: 'italic' },
+          }, 'Search below for periods to add')
+    ]),
+
+    atLimit
+      ? null
+      : h(Autosuggest, {
+          theme: {
+            suggestionsContainer: {
+              boxSizing: 'border-box',
+              position: 'absolute',
+              left: 0,
+              right: 0,
+            },
+            suggestionsContainerOpen: {
+              border: '1px solid #ccc',
+              height: 164,
+              boxShadow: '2px 1px 4px #ddd',
+            }
+          },
+          multiSection: true,
+          getSuggestions: getSuggestions(authorities, suggestionFilter),
+          renderSectionTitle,
+          renderSuggestion,
+          getSectionSuggestions: section => section.suggestions,
+          inputProps: {
+            placeholder: 'Begin typing to search for periods to add',
+            id: randomID(name),
+            borderRadius: '0 0 2px 2px'
+          },
+          onSelect: period => onValueChange(periods.concat(period))
+        })
+  ])
+}
+
+module.exports = RandomID(RelatedPeriodList)

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const h = require('react-hyperscript')
+    , R = require('ramda')
     , { Route } = require('org-shell')
     , { RandomID } = require('periodo-common')
     , { Flex, Box, Link, Text, Label } = require('periodo-ui')
@@ -51,6 +52,8 @@ const matches = query => {
   }
 }
 
+const byName = R.comparator((a, b) => R.prop('name', a) < R.prop('name', b))
+
 const getSuggestions = (authorities, suggestionFilter) => (query = '') => (
   authorities
     .map(authority => ({
@@ -58,7 +61,7 @@ const getSuggestions = (authorities, suggestionFilter) => (query = '') => (
       suggestions: Object.values(authority.periods)
         .reduce(matches(query), [])
         .filter(suggestionFilter)
-        //.filter(({ id }) => ! excludePeriodIDs.includes(id))
+        .sort(byName)
     }))
     .filter(section => section.suggestions.length > 0)
 )

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -109,7 +109,7 @@ const RelatedPeriod = ({
         authorityID: authority.id,
         periodID: period.id,
       })
-    }, util.period.originalLabel(period).label),
+    }, period.label),
     h(Text, `${spatialCoverageOf(period)}, ${temporalCoverageOf(period)}`),
     h(Text, util.authority.displayTitle(authority))
   ])

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -2,10 +2,11 @@
 
 const h = require('react-hyperscript')
     , R = require('ramda')
+    , { useContext } = require('react')
     , { Route } = require('org-shell')
     , { RandomID } = require('periodo-common')
-    , { Flex, Box, Link, Text, Label } = require('periodo-ui')
-    , { Autosuggest } = require('periodo-ui')
+    , { Flex, Box, Link, Text, Label, Autosuggest } = require('periodo-ui')
+    , { BackendContext } = require('periodo-ui')
     , util = require('periodo-utils')
 
 const spatialCoverageOf = period => period.spatialCoverageDescription
@@ -96,7 +97,6 @@ const renderSuggestion = (item, { isHighlighted }) => h(Box,
 
 const RelatedPeriod = ({
   period,
-  backendID,
   ...props
 }) => {
 
@@ -105,7 +105,7 @@ const RelatedPeriod = ({
   return h(Box, props, [
     h(Link, {
       route: Route('period-view', {
-        backendID,
+        backendID: useContext(BackendContext).asIdentifier(),
         authorityID: authority.id,
         periodID: period.id,
       })

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodList.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const h = require('react-hyperscript')
-    , R = require('ramda')
     , { Route } = require('org-shell')
     , { RandomID } = require('periodo-common')
     , { Flex, Box, Link, Text, Label } = require('periodo-ui')
@@ -127,30 +126,11 @@ const Deletable = ({ children, onDelete, ...props }) => h(Flex, {
   h(Box, { flex: '1 1' }, children)
 ])
 
-const getPeriods = (authorities, periodIDs) => {
-  if (! periodIDs) {
-    return []
-  }
-  if (! Array.isArray(periodIDs)) {
-    periodIDs = [ periodIDs ]
-  }
-  let periods = {}
-  for (const authority of authorities) {
-    periods = { ...R.pick(periodIDs, authority.periods) }
-    if (Object.keys(periods).length === periodIDs.length) {
-      break
-    }
-  }
-  return Object.values(periods).sort(R.comparator((a, b) => (
-    util.terminus.earliestYear(a.start) <  util.terminus.earliestYear(b.start)
-  )))
-}
-
 const RelatedPeriodList = ({
   name,
   label,
   helpText,
-  periodIDs,
+  periods,
   suggestionFilter=() => true,
   limit,
   authorities,
@@ -160,8 +140,7 @@ const RelatedPeriodList = ({
   ...props
 }) => {
 
-  const periods = getPeriods(authorities, periodIDs)
-      , atLimit = limit && periods.length >= limit
+  const atLimit = limit && periods.length >= limit
 
   return h(Box, { css: { position: 'relative' }, ...props }, [
     h(Label, { htmlFor: randomID(name) }, label),

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
@@ -11,7 +11,6 @@ const $$RelatedPeriods = Symbol.for('RelatedPeriods')
 const RelatedPeriodsForm = ({
     value,
     onValueChange,
-    backendID,
     dataset,
     authority,
 }) => {
@@ -44,7 +43,6 @@ const RelatedPeriodsForm = ({
           ({ id }) => value.id !== id && ! value.narrower.includes(id),
         limit: 1,
         authorities: [ authority ],
-        backendID,
         onValueChange: update('broader')
       }),
       h(RelatedPeriodList, {
@@ -55,7 +53,6 @@ const RelatedPeriodsForm = ({
         periods: R.sort(period.byStartYear, periods.narrower),
         suggestionFilter: ({ id }) => value.id !== id && value.broader !== id,
         authorities: [ authority ],
-        backendID,
         onValueChange: update('narrower')
       })
     ]),
@@ -68,7 +65,6 @@ const RelatedPeriodsForm = ({
         periods: periods.derivedFrom,
         suggestionFilter: ({ id }) => value.id !== id,
         authorities: Object.values(dataset.authorities),
-        backendID,
         onValueChange: update('derivedFrom')
       })
     ]),

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
@@ -6,6 +6,8 @@ const h = require('react-hyperscript')
     , { valueAsArray, terminus } = require('periodo-utils')
     , RelatedPeriodList = require('./RelatedPeriodList')
 
+const $$RelatedPeriods = Symbol.for('RelatedPeriods')
+
 const byStartYear = R.comparator(
   (a, b) => terminus.earliestYear(a.start) < terminus.earliestYear(b.start)
 )
@@ -18,15 +20,16 @@ const RelatedPeriodsForm = ({
     authority,
 }) => {
 
-  const related = Symbol.for('RelatedPeriods')
   const periods = R.fromPairs(['broader', 'narrower', 'derivedFrom'].map(
     prop => [
-      prop, valueAsArray(prop, value).map(id => value[related][prop][id])
+      prop, valueAsArray(prop, value).map(
+        id => value[$$RelatedPeriods][prop][id]
+      )
     ]
   ))
   const update = prop => periods => {
     value[prop] = periods.map(({ id }) => id)
-    value[related][prop] = R.indexBy(R.prop('id'), periods)
+    value[$$RelatedPeriods][prop] = R.indexBy(R.prop('id'), periods)
     onValueChange(value)
   }
 

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
@@ -3,14 +3,10 @@
 const h = require('react-hyperscript')
     , R = require('ramda')
     , { Flex, Box } = require('periodo-ui')
-    , { valueAsArray, terminus } = require('periodo-utils')
+    , { valueAsArray, period } = require('periodo-utils')
     , RelatedPeriodList = require('./RelatedPeriodList')
 
 const $$RelatedPeriods = Symbol.for('RelatedPeriods')
-
-const byStartYear = R.comparator(
-  (a, b) => terminus.earliestYear(a.start) < terminus.earliestYear(b.start)
-)
 
 const RelatedPeriodsForm = ({
     value,
@@ -56,7 +52,7 @@ const RelatedPeriodsForm = ({
         name: 'narrower',
         label: 'Has parts',
         helpText: 'Narrower periods contained by this one',
-        periods: R.sort(byStartYear, periods.narrower),
+        periods: R.sort(period.byStartYear, periods.narrower),
         suggestionFilter: ({ id }) => value.id !== id && value.broader !== id,
         authorities: [ authority ],
         backendID,

--- a/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
+++ b/modules/periodo-app/src/forms/PeriodForm/RelatedPeriodsForm.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const h = require('react-hyperscript')
+    , R = require('ramda')
+    , { Flex, Box } = require('periodo-ui')
+    , RelatedPeriodList = require('./RelatedPeriodList')
+
+
+const RelatedPeriodsForm = ({
+    value,
+    onValueChange,
+    backendID,
+    dataset,
+    authority,
+}) => {
+
+  return h(Flex, {
+    pb: 2,
+    borderBottom: '1px solid #ccc'
+  }, [
+
+    h(Box, { width: .5, px: 3 }, [
+      h(RelatedPeriodList, {
+        name: 'broader',
+        label: 'Part of',
+        helpText: 'Broader period containing this one',
+        periodIDs: value.broader,
+        suggestionFilter:
+          ({ id }) => value.id !== id && ! value.narrower.includes(id),
+        limit: 1,
+        authorities: [ authority ],
+        backendID,
+        onValueChange: periods => onValueChange(
+          periods.length
+            ? R.assoc('broader', periods[0].id, value)
+            : R.dissoc('broader', value)
+        )
+      }),
+      h(RelatedPeriodList, {
+        mt: 2,
+        name: 'narrower',
+        label: 'Has parts',
+        helpText: 'Narrower periods contained by this one',
+        periodIDs: value.narrower,
+        suggestionFilter: ({ id }) => value.id !== id && value.broader !== id,
+        authorities: [ authority ],
+        backendID,
+        onValueChange: periods => onValueChange(
+          R.assoc('narrower', periods.map(({ id }) => id), value)
+        )
+      })
+    ]),
+
+    h(Box, { width: .5, px: 3 }, [
+      h(RelatedPeriodList, {
+        name: 'derived-from',
+        label: 'Derived from',
+        helpText: 'Other periods from which this one was derived',
+        periodIDs: value.derivedFrom,
+        suggestionFilter: ({ id }) => value.id !== id,
+        authorities: Object.values(dataset.authorities),
+        backendID,
+        onValueChange: periods => onValueChange(
+          R.assoc('derivedFrom', periods.map(({ id }) => id), value)
+        )
+      })
+    ]),
+  ])
+}
+
+module.exports = RelatedPeriodsForm

--- a/modules/periodo-app/src/forms/PeriodForm/index.js
+++ b/modules/periodo-app/src/forms/PeriodForm/index.js
@@ -23,7 +23,6 @@ module.exports = Validated(validatePeriod, props => {
   const {
     value={},
     onValueChange=R.always(null),
-    backendID,
     dataset,
     authority,
     errors,
@@ -104,7 +103,6 @@ module.exports = Validated(validatePeriod, props => {
         h(RelatedPeriodsForm, {
           value,
           onValueChange,
-          backendID,
           dataset,
           authority,
           pb: 2,

--- a/modules/periodo-app/src/forms/PeriodForm/index.js
+++ b/modules/periodo-app/src/forms/PeriodForm/index.js
@@ -5,6 +5,7 @@ const h = require('react-hyperscript')
     , LabelForm = require('./LabelForm')
     , { Flex, Box, Heading } = require('periodo-ui')
     , { InputBlock, TextareaBlock, Button$Primary, Errors } = require('periodo-ui')
+    , RelatedPeriodsForm = require('./RelatedPeriodsForm')
     , TemporalCoverageForm = require('./TemporalCoverageForm')
     , SpatialCoverageForm = require('./SpatialCoverageForm')
     , Validated = require('../Validated')
@@ -19,7 +20,14 @@ const lenses = {
 }
 
 module.exports = Validated(validatePeriod, props => {
-  const { value={}, onValueChange=R.always(null), errors } = props
+  const {
+    value={},
+    onValueChange=R.always(null),
+    backendID,
+    dataset,
+    authority,
+    errors,
+  } = props
 
   const get = lens => R.view(lens, value) || ''
       , set = (lens, val) => onValueChange(R.set(lens, val, value))
@@ -27,13 +35,14 @@ module.exports = Validated(validatePeriod, props => {
   return (
     h(Box, {}, [
       h(Box, {
-        p: 2,
+        py: 2,
+        px: 3,
         border: 1,
         borderColor: '#ccc',
         css: {
           borderRadius: '6px 6px 0 0',
         },
-        bg: 'gray0',
+        bg: 'gray.0',
       }, [
         h(Heading, {
           level: 3,
@@ -89,6 +98,18 @@ module.exports = Validated(validatePeriod, props => {
             })
           ]),
         ]),
+
+        h(Heading, { level: 3, px: 3, py: 2 }, 'Related periods'),
+
+        h(RelatedPeriodsForm, {
+          value,
+          onValueChange,
+          backendID,
+          dataset,
+          authority,
+          pb: 2,
+          borderBottom: '1px solid #ccc'
+        }),
 
         h(Flex, {
           css: {

--- a/modules/periodo-app/src/forms/validate.js
+++ b/modules/periodo-app/src/forms/validate.js
@@ -46,6 +46,9 @@ const VALID_PERIOD_FIELDS = [
   'language',
   'languageTag',
   'localizedLabels',
+  'derivedFrom',
+  'broader',
+  'narrower',
   'spatialCoverage',
   'spatialCoverageDescription',
   'start',
@@ -84,6 +87,9 @@ function validatePeriod(period) {
       errors = addError(errors, 'dates', 'Date range for period stop has a beginning later than its end.')
     }
   }
+
+  // FIXME We could check here for cycles in derivedFrom and broader relations.
+  // But for now it seems not worth the expense of checking the entire dataset.
 
   if (R.equals(errors, {})) {
     const cleanedPeriod = {

--- a/modules/periodo-app/src/forms/validate.js
+++ b/modules/periodo-app/src/forms/validate.js
@@ -108,6 +108,25 @@ function validatePeriod(period) {
     delete cleanedPeriod.start._type;
     delete cleanedPeriod.stop._type;
 
+    // Clean up related period arrays
+    if (
+      'derivedFrom' in cleanedPeriod
+      && Array.isArray(cleanedPeriod.derivedFrom)
+      && cleanedPeriod.derivedFrom.length === 0
+    ) {
+      delete cleanedPeriod.derivedFrom
+    }
+    if (
+      'broader' in cleanedPeriod
+      && Array.isArray(cleanedPeriod.broader)
+    ) {
+      if (cleanedPeriod.broader.length == 0) {
+        delete cleanedPeriod.broader
+      } else if (cleanedPeriod.broader.length == 1) {
+        cleanedPeriod.broader = cleanedPeriod.broader[0]
+      }
+    }
+
     return Result.Ok(cleanedPeriod);
 
   } else {

--- a/modules/periodo-ui/src/Autosuggest.js
+++ b/modules/periodo-ui/src/Autosuggest.js
@@ -89,7 +89,7 @@ exports.Autosuggest = class _Autosuggest extends React.Component {
                 cursor: 'pointer',
               }
             }
-          }, isHighlighted && { bg: 'gray2' }), [
+          }, isHighlighted && { bg: 'gray.2' }), [
             item.name
           ]),
 

--- a/modules/periodo-ui/src/BackendContext.js
+++ b/modules/periodo-ui/src/BackendContext.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const { createContext } = require('react')
+
+exports.BackendContext = createContext()

--- a/modules/periodo-ui/src/Field.js
+++ b/modules/periodo-ui/src/Field.js
@@ -7,7 +7,7 @@ const h = require('react-hyperscript')
     , { InfoText, WarnText } = require('./Typography')
     , { Value, Change, asValue } = require('./types')
     , { findChanges, showChanges } = require('./Diff')
-    , { ensureArray } = require('./util')
+    , { ensureArray } = require('periodo-utils')
 
 const extract = keyOrPath => R.pipe(
   R.pathOr([], ensureArray(keyOrPath)),

--- a/modules/periodo-ui/src/Period.js
+++ b/modules/periodo-ui/src/Period.js
@@ -11,7 +11,7 @@ const R = require('ramda')
       , SpatialExtentValue
       , LanguageSpecificValue
       } = require('./Value')
-    , { ensureArray } = require('./util')
+    , { ensureArray } = require('periodo-utils')
 
 const extractSpatialExtent = period => {
   const description = period.spatialCoverageDescription || ''

--- a/modules/periodo-ui/src/Value.js
+++ b/modules/periodo-ui/src/Value.js
@@ -91,11 +91,12 @@ function LinkValue(props) {
 
 function RelatedPeriodValue(props) {
   const { value: period } = props
+  const backend = useContext(BackendContext)
   return h(
     Link,
     {
       route: Route('period-view', {
-        backendID: useContext(BackendContext).asIdentifier(),
+        backendID: backend.asIdentifier(),
         authorityID: util.period.authorityOf(period).id,
         periodID: period.id,
       })

--- a/modules/periodo-ui/src/Value.js
+++ b/modules/periodo-ui/src/Value.js
@@ -3,12 +3,16 @@
 const h = require('react-hyperscript')
     , R = require('ramda')
     , tags = require('language-tags')
+    , { Route } = require('org-shell')
     , { Box, Span, Pre } = require('./Base')
     , { Italic } = require('./Typography')
-    , { ExternalLink } = require('./Links')
+    , { Link, ExternalLink } = require('./Links')
     , { Diff, findChanges, showChanges } = require('./Diff')
+    , { BackendContext } = require('./BackendContext')
+    , { useContext } = require('react')
     , { Value } = require('./types')
     , linkifier = require('linkify-it')()
+    , util = require('periodo-utils')
 
 const abbreviate = id => {
   try {
@@ -82,6 +86,21 @@ function LinkValue(props) {
   const { value } = props
   return h(
     ExternalLink, R.merge(R.omit([ 'value' ], props), { href: value }), value
+  )
+}
+
+function RelatedPeriodValue(props) {
+  const { value: period } = props
+  return h(
+    Link,
+    {
+      route: Route('period-view', {
+        backendID: useContext(BackendContext).asIdentifier(),
+        authorityID: util.period.authorityOf(period).id,
+        periodID: period.id,
+      })
+    },
+    period.label
   )
 }
 
@@ -213,5 +232,6 @@ module.exports = {
   LinkifiedTextValue,
   AgentValue,
   SpatialExtentValue,
-  JSONLDContextValue
+  JSONLDContextValue,
+  RelatedPeriodValue
 }

--- a/modules/periodo-ui/src/index.js
+++ b/modules/periodo-ui/src/index.js
@@ -29,4 +29,5 @@ addUIModules([
   require('./Links'),
   require('./Autosuggest'),
   require('./Base'),
+  require('./BackendContext'),
 ])

--- a/modules/periodo-ui/src/util.js
+++ b/modules/periodo-ui/src/util.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const R = require('ramda')
-    , ss = require('styled-system')
+const ss = require('styled-system')
 
 const ssProps = Object.values(ss.propTypes)
   .map(Object.keys)
@@ -11,9 +10,6 @@ function blacklist(...keys) {
   return ssProps.concat(keys)
 }
 
-const ensureArray = R.ifElse(Array.isArray, R.identity, Array.of)
-
 module.exports = {
   blacklist,
-  ensureArray,
 }

--- a/modules/periodo-utils/src/index.js
+++ b/modules/periodo-utils/src/index.js
@@ -12,4 +12,5 @@ module.exports = {
   symbols: require('./symbols'),
   terminus: require('./terminus'),
   terminusList: require('./terminus_list'),
+  ...require('./util')
 }

--- a/modules/periodo-utils/src/period.js
+++ b/modules/periodo-utils/src/period.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const R = require('ramda')
+    , { earliestYear } = require('./terminus')
     , { $$Authority } = require('./symbols')
 
 function originalLabel(period) {
@@ -38,10 +39,15 @@ function periodWithAuthority(period) {
   }
 }
 
+const byStartYear = R.comparator(
+  (a, b) => earliestYear(a.start) < earliestYear(b.start)
+)
+
 module.exports = {
   originalLabel,
   allLabels,
   alternateLabels,
   authorityOf,
   periodWithAuthority,
+  byStartYear,
 }

--- a/modules/periodo-utils/src/util.js
+++ b/modules/periodo-utils/src/util.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const R = require('ramda')
+
 function oneOf(...candidates) {
   return x => {
     for (let i = 0; i < candidates.length; i++) {
@@ -9,6 +11,14 @@ function oneOf(...candidates) {
   }
 }
 
+const ensureArray = R.ifElse(Array.isArray, R.identity, Array.of)
+
+const valueAsArray = R.curry(
+  (prop, obj) => ensureArray(R.propOr([], prop, obj))
+)
+
 module.exports = {
   oneOf,
+  ensureArray,
+  valueAsArray,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "periodo-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3192,6 +3192,16 @@
         "once": "^1.4.0"
       }
     },
+    "envify": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-4.1.0.tgz",
+      "integrity": "sha512-IKRVVoAYr4pIx4yIWNsz9mOsboxlNXiu7TNBnem/K/uTHdkyzXWDzHCK7UTolqBbgaBz0tQHsD3YNls0uIIjiw==",
+      "dev": true,
+      "requires": {
+        "esprima": "^4.0.0",
+        "through": "~2.3.4"
+      }
+    },
     "err-code": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "blue-tape": "^1.0.0",
     "browserify": "^16.2.3",
     "common-shakeify": "^0.5.0",
+    "envify": "^4.1.0",
     "exorcist": "^1.0.1",
     "fake-indexeddb": "^2.0.4",
     "lerna": "^3.14.1",
@@ -28,6 +29,7 @@
   },
   "browserify": {
     "transform": [
+      "envify",
       "common-shakeify"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "periodo-client",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "author": "Patrick Golden <ptgolden@email.unc.edu>",
   "contributors": [
     "Ryan Shaw <ryanshaw@unc.edu>"


### PR DESCRIPTION
Implements editing and viewing of related periods (derived from, broader, narrower).

ID references to related periods are resolved in the reducer and stored as symbols on period objects. This is hacky and should be replaced with use of a backend method to resolve a period ID to a period.

Speaking of which: this pull request adds modules/periodo-ui/src/BackendContext.js which is used to access the current backend from deep in a component tree (so that internal links to other periods can be constructed). This is super handy, and having this plus utility methods on the backend object would be 🆒 