### PR TITLE
Map cleanup

### DIFF
--- a/modules/periodo-ui/src/Value.js
+++ b/modules/periodo-ui/src/Value.js
@@ -221,20 +221,18 @@ function SpatialExtentValue(props) {
     .map(([{id}]) => gazetteers.find(id))
     .filter(R.identity)
 
-  const showMap = (!compare && features.length > 0)
-
   return (
     h('div', [
       h(Annotated, R.merge(
         R.omit([ 'value', 'compare' ], props),
         annotationProps
       )),
-      !showMap ? null : (
+      compare ? null : (
         h(WorldMap, {
           mt: 1,
           border: '1px solid #ccc',
           maxWidth: '650px',
-          features: places.map(([{id}]) => gazetteers.find(id))
+          features
         })
       )
     ])

--- a/modules/periodo-ui/src/WorldMap.js
+++ b/modules/periodo-ui/src/WorldMap.js
@@ -4,10 +4,8 @@ const R = require('ramda')
     , regl = require('regl')
     , resl = require('resl')
     , mixmap = require('mixmap')
-    , zoomTo = require('mixmap-zoom')
     , glsl = require('glslify')
     , createMesh = require('earth-mesh')
-    , easing = require('eases/circ-out')
     , h = require('react-hyperscript')
     , { useRef, useLayoutEffect } = require('react')
     , { Box } = require('./Base')
@@ -15,11 +13,58 @@ const R = require('ramda')
 
 const tiles = require('../../../images/maptiles/manifest.json')
 
-const mix = mixmap(regl)
-const map = mix.create({backgroundColor: [0, 0, 0, 0]})
+const length = bbox => {
+  const lonDelta = bbox[2] - bbox[0]
+  const latDelta = bbox[3] - bbox[1]
+  if (lonDelta > 359) {
+    return latDelta
+  }
+  return Math.max(lonDelta, latDelta)
+}
 
-const drawTile = map.createDraw({
-  frag: glsl`
+const ln360 = Math.log2(360)
+
+const bboxToZoom = bbox => {
+  const dx = bbox[2] - bbox[0]
+  const dy = bbox[3] - bbox[1]
+  const d = Math.max(dx,dy)
+  const zoom = ln360 - Math.log2(d) + 1
+  return Math.max(Math.min(zoom,21),1)
+}
+
+const zoomToBbox = (bbox,zoom) => {
+  const dx = bbox[2] - bbox[0]
+  const dy = bbox[3] - bbox[1]
+  const d = Math.pow(2, ln360 - zoom)
+  const x = (bbox[2] + bbox[0]) * 0.5
+  const y = (bbox[3] + bbox[1]) * 0.5
+  const sx = dx < dy ? dx / dy : 1
+  const sy = dy < dx ? dy / dx : 1
+  bbox[0] = x - d * sx
+  bbox[1] = y - d * sy
+  bbox[2] = x + d * sx
+  bbox[3] = y + d * sy
+  return bbox
+}
+
+const pad = (map, bbox) => {
+
+  const zoom = bboxToZoom(bbox)
+
+  const padding = Math.max(1,
+    // the coefficients here were determined through trial & error
+    Math.round((-0.68 * Math.log(length(bbox))) + 3.91)
+  ) + (map._size[0] > map._size[1] ? map._size[0]/map._size[1]*0.5 : 0)
+
+  return padding ? zoomToBbox(bbox, zoom - padding) : bbox
+}
+
+const initializeMap = mix => {
+
+  const map = mix.create({backgroundColor: [0, 0, 0, 0]})
+
+  const drawTile = map.createDraw({
+    frag: glsl`
     precision highp float;
     #pragma glslify: hsl2rgb = require('glsl-hsl2rgb')
     uniform float id;
@@ -33,8 +78,8 @@ const drawTile = map.createDraw({
       vec4 tc = texture2D(texture,vtcoord);
       gl_FragColor = vec4(c*(1.0-tc.a)+tc.rgb*tc.a,0.5+tc.a*0.5);
     }
-  `,
-  vert: `
+    `,
+    vert: `
     precision highp float;
     attribute vec2 position;
     uniform vec4 viewbox;
@@ -50,161 +95,146 @@ const drawTile = map.createDraw({
         ((p.y - viewbox.y) / (viewbox.w - viewbox.y) * 2.0 - 1.0) * aspect,
         1.0/(2.0+zindex), 1);
     }
-  `,
-  uniforms: {
-    id: map.prop('id'),
-    zindex: map.prop('zindex'),
-    texture: map.prop('texture')
-  },
-  attributes: {
-    position: map.prop('points'),
-    tcoord: [0,1,0,0,1,1,1,0] // sw,se,nw,ne
-  },
-  elements: [0,1,2,1,2,3],
-  blend: {
-    enable: true,
-    func: { src: 'src alpha', dst: 'one minus src alpha' }
-  }
-})
-
-map.addLayer({
-  viewbox(bbox, zoom, cb) {
-    zoom = Math.round(zoom)
-    if (zoom < 2) cb(null, tiles[0])
-    else if (zoom < 4) cb(null, tiles[1])
-    else cb(null, tiles[2])
-  },
-  add(key, bbox) {
-    const file = key.split('!')[1]
-    const level = Number(file.split('/')[0])
-    const prop = {
-      id: Number(key.split('!')[0]),
-      key,
-      zindex: 2 + level,
-      texture: map.regl.texture(),
-      points: [
-        bbox[0], bbox[1], // sw
-        bbox[0], bbox[3], // se
-        bbox[2], bbox[1], // nw
-        bbox[2], bbox[3]  // ne
-      ]
+    `,
+    uniforms: {
+      id: map.prop('id'),
+      zindex: map.prop('zindex'),
+      texture: map.prop('texture')
+    },
+    attributes: {
+      position: map.prop('points'),
+      tcoord: [0,1,0,0,1,1,1,0] // sw,se,nw,ne
+    },
+    elements: [0,1,2,1,2,3],
+    blend: {
+      enable: true,
+      func: { src: 'src alpha', dst: 'one minus src alpha' }
     }
-    drawTile.props.push(prop)
-    map.draw()
-    resl({
-      manifest: { tile: { type: 'image', src: '/images/maptiles/'+file } },
-      onDone(assets) {
-        prop.texture = map.regl.texture(assets.tile)
-        map.draw()
+  })
+
+  map.addLayer({
+    viewbox(bbox, zoom, cb) {
+      zoom = Math.round(zoom)
+      if (zoom < 2) cb(null, tiles[0])
+      else if (zoom < 4) cb(null, tiles[1])
+      else cb(null, tiles[2])
+    },
+    add(key, bbox) {
+      const file = key.split('!')[1]
+      const level = Number(file.split('/')[0])
+      const prop = {
+        id: Number(key.split('!')[0]),
+        key,
+        zindex: 2 + level,
+        texture: map.regl.texture(),
+        points: [
+          bbox[0], bbox[1], // sw
+          bbox[0], bbox[3], // se
+          bbox[2], bbox[1], // nw
+          bbox[2], bbox[3]  // ne
+        ]
       }
-    })
-  },
-  remove(key) {
-    drawTile.props = drawTile.props.filter(p => p.key !== key)
-  }
-})
+      drawTile.props.push(prop)
+      map.draw()
+      resl({
+        manifest: { tile: { type: 'image', src: '/images/maptiles/'+file } },
+        onDone(assets) {
+          prop.texture = map.regl.texture(assets.tile)
+          map.draw()
+        }
+      })
+    },
+    remove(key) {
+      drawTile.props = drawTile.props.filter(p => p.key !== key)
+    }
+  })
 
-const PURPLE = 'vec4(1.0,0.0,1.0,0.5)'
-const YELLOW = 'vec4(1.0,1.0,0.0,0.5)'
+  const PURPLE = 'vec4(1.0,0.0,1.0,0.5)'
+  const YELLOW = 'vec4(1.0,1.0,0.0,0.5)'
 
-const drawTriangle = color => map.createDraw({
-  frag: `
+  const drawTriangle = color => map.createDraw({
+    frag: `
     void main () {
       gl_FragColor = ${color};
     }
   `,
-  uniforms: {
-    zindex: 100
-  },
-  blend: {
-    enable: true,
-    func: { src: 'src alpha', dst: 'one minus src alpha' }
-  },
-  attributes: {
-    position: map.prop('positions')
-  },
-  elements: map.prop('cells')
-})
+    uniforms: {
+      zindex: 100
+    },
+    blend: {
+      enable: true,
+      func: { src: 'src alpha', dst: 'one minus src alpha' }
+    },
+    attributes: {
+      position: map.prop('positions')
+    },
+    elements: map.prop('cells')
+  })
 
-const drawFeatures = drawTriangle(YELLOW)
-const drawFocusedFeature = drawTriangle(PURPLE)
+  const drawFeatures = drawTriangle(YELLOW)
+  const drawFocusedFeature = drawTriangle(PURPLE)
 
-const length = bbox => {
-  const lonDelta = bbox[2] - bbox[0]
-  const latDelta = bbox[3] - bbox[1]
-  if (lonDelta > 359) {
-    return latDelta
+  const bbox = mesh => {
+    const box = [180,90,-180,-90]
+    for (let i = 0; i < mesh.triangle.positions.length; i++) {
+      box[0] = Math.min(box[0], mesh.triangle.positions[i][0])
+      box[1] = Math.min(box[1], mesh.triangle.positions[i][1])
+      box[2] = Math.max(box[2], mesh.triangle.positions[i][0])
+      box[3] = Math.max(box[3], mesh.triangle.positions[i][1])
+    }
+    return box
   }
-  return Math.max(lonDelta, latDelta)
-}
 
-const padding = bbox => Math.max(1,
-  // the coefficients here were determined through trial & error
-  Math.round((-0.68 * Math.log(length(bbox))) + 3.91)
-)
+  map.display = (features, focusedFeature) => {
+    const focusedFeatureId = focusedFeature ? focusedFeature.id : undefined
+    const unfocusedFeatures = features.filter(
+      f => (f.id !== focusedFeatureId) && f.geometry
+    )
+    let viewbox = undefined
+    if (unfocusedFeatures.length > 0) {
+      const mesh = createMesh({features: unfocusedFeatures})
+      drawFeatures.props = [mesh.triangle]
+      viewbox = bbox(mesh)
+    } else {
+      drawFeatures.props = []
+    }
+    if (focusedFeature && focusedFeature.geometry) {
+      const mesh = createMesh(focusedFeature)
+      drawFocusedFeature.props = [mesh.triangle]
+      viewbox = bbox(mesh)
+    } else {
+      drawFocusedFeature.props = []
+    }
+    if (viewbox) {
+      map.setViewbox(pad(map, viewbox))
+    }
+    map.draw()
+  }
 
-const bbox = mesh => {
-  const box = [180,90,-180,-90]
-  for (let i = 0; i < mesh.triangle.positions.length; i++) {
-    box[0] = Math.min(box[0], mesh.triangle.positions[i][0])
-    box[1] = Math.min(box[1], mesh.triangle.positions[i][1])
-    box[2] = Math.max(box[2], mesh.triangle.positions[i][0])
-    box[3] = Math.max(box[3], mesh.triangle.positions[i][1])
-  }
-  return box
-}
-
-const zoom = viewbox => zoomTo(map, {
-  viewbox, duration: 750, padding: padding(viewbox), easing
-})
-
-const display = (features, focusedFeature) => {
-  const focusedFeatureId = focusedFeature ? focusedFeature.id : undefined
-  const unfocusedFeatures = features.filter(
-    f => (f.id !== focusedFeatureId) && f.geometry
-  )
-  let viewbox = undefined
-  if (unfocusedFeatures.length > 0) {
-    const mesh = createMesh({features: unfocusedFeatures})
-    drawFeatures.props = [mesh.triangle]
-    viewbox = bbox(mesh)
-  } else {
-    drawFeatures.props = []
-  }
-  if (focusedFeature && focusedFeature.geometry) {
-    const mesh = createMesh(focusedFeature)
-    drawFocusedFeature.props = [mesh.triangle]
-    viewbox = bbox(mesh)
-  } else {
-    drawFocusedFeature.props = []
-  }
-  map.draw()
-  if (viewbox) {
-    zoom(viewbox)
-  }
+  return map
 }
 
 // shared webgl context, only needs to be rendered once
+const mix = mixmap(regl)
 const renderMix = R.once(() => document.body.appendChild(mix.render()))
-
-const removeAllChildren = node => {
-  while (node.firstChild) {
-    node.removeChild(node.firstChild)
-  }
-}
 
 const _Map = ({ features=[], focusedFeature, height }) => {
 
   const innerRef = useRef()
       , outerRef = useRef()
       , width = useRect(outerRef).width
+      , map = initializeMap(mix)
+
+  renderMix()
+
+  const mapNode = map.render({width, height})
+
+  map.display(features, focusedFeature)
 
   useLayoutEffect(() => {
-    renderMix()
-    innerRef.current.appendChild(map.render({width, height}))
-    display(features, focusedFeature)
+    innerRef.current.appendChild(mapNode)
     return function cleanup() {
-      removeAllChildren(innerRef.current)
+      innerRef.current.removeChild(mapNode)
     }
   })
 


### PR DESCRIPTION
Remove the animated map zooming, and re-initialize the scissored map context on each render. This seems to stop the problems with tiles sometimes failing to load.

Show map even when there are no spatial coverage features. This prevents the issue where a ghost map is rendered even though the DOM node has been removed (see https://github.com/peermaps/mixmap/issues/5).