### PR TITLE
Map visualization facet

### DIFF
--- a/modules/org-layouts/src/LayoutRenderer.js
+++ b/modules/org-layouts/src/LayoutRenderer.js
@@ -77,7 +77,6 @@ class LayoutBlock extends React.Component {
           gridColumn,
           minWidth: 0,
           minHeight: 0,
-          overflow: 'hidden',
         },
       }, [
         h(Component, {
@@ -252,6 +251,7 @@ class LayoutRenderer extends React.Component {
           gridTemplateColumns: processedLayout.gridTemplateColumns,
           gridTemplateRows: processedLayout.gridTemplateRows,
           gridGap: processedLayout.gridGap,
+          overflow: 'hidden',
         },
       }, children)
     )

--- a/modules/periodo-app/src/backends/components/BackendHome.js
+++ b/modules/periodo-app/src/backends/components/BackendHome.js
@@ -17,17 +17,17 @@ type = text-search
 grid-column = 1/7
 grid-row = 1/2
 
+[SpatialCoverage]
+type = spatial-visualization
+grid-column = 1/4
+grid-row = 2/3
+
 [Facets]
 type = facets
 flex = true
 height = 156
 grid-column = 1/7
 grid-row = 3/4
-
-[SpatialCoverage]
-type = spatial-visualization
-grid-column = 1/4
-grid-row = 2/3
 
 [TimeRange]
 type = timespan-visualization

--- a/modules/periodo-app/src/backends/components/BackendHome.js
+++ b/modules/periodo-app/src/backends/components/BackendHome.js
@@ -14,7 +14,7 @@ grid-gap = 1em 1.66em
 
 [Search]
 type = text-search
-grid-column = 1/3
+grid-column = 1/7
 grid-row = 1/2
 
 [Facets]
@@ -22,28 +22,33 @@ type = facets
 flex = true
 height = 156
 grid-column = 1/7
+grid-row = 3/4
+
+[SpatialCoverage]
+type = spatial-visualization
+grid-column = 1/4
 grid-row = 2/3
 
 [TimeRange]
 type = timespan-visualization
-grid-column = 3/7
-grid-row = 1/2
+grid-column = 4/7
+grid-row = 2/3
 height = 200
 
 [PeriodList]
 type = windowed-period-list
 grid-column = 1/7
-grid-row = 3/4
+grid-row = 4/5
 
 [PeriodDetail]
 type = period-detail
 grid-column = 1/4
-grid-row = 4/5
+grid-row = 5/6
 
 [AuthorityDetail]
 type = authority-detail
 grid-column = 4/7
-grid-row = 4/5
+grid-row = 5/6
 `
 
 const authorityLayout = `

--- a/modules/periodo-app/src/forms/PeriodForm/SpatialCoverageForm/index.js
+++ b/modules/periodo-app/src/forms/PeriodForm/SpatialCoverageForm/index.js
@@ -4,8 +4,7 @@ const h = require('react-hyperscript')
     , R = require('ramda')
     , { useState } = require('react')
     , { Box, Text, InputBlock, Label, Tags } = require('periodo-ui')
-    , LabeledMap = require('./LabeledMap')
-    , PlaceSuggest = require('./PlaceSuggest')
+    , { LabeledMap, PlaceSuggest } = require('periodo-ui')
 
 const SpatialCoverageForm = ({
   onValueChange,

--- a/modules/periodo-app/src/layouts/authorities/CoverageMap/index.js
+++ b/modules/periodo-app/src/layouts/authorities/CoverageMap/index.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const h = require('react-hyperscript')
+    , { WorldMap } = require('periodo-ui')
+
+const CoverageMap = ({ data: periods, gazetteers }) => {
+  const featureSet = periods.reduce(
+    (featureSet, period) => {
+      (period.spatialCoverage || [])
+        .map(({ id }) => gazetteers.find(id))
+        .filter(feature => feature !== null)
+        .forEach(feature => featureSet.add(feature))
+      return featureSet
+    },
+    new Set()
+  )
+  return h(WorldMap, {
+    height: 256,
+    border: '1px solid #ccc',
+    features: [ ...featureSet ],
+  })
+}
+
+module.exports = {
+  label: 'Spatial coverage map',
+  description: 'WebGL map showing spatial coverage of selected periods',
+  Component: CoverageMap,
+}

--- a/modules/periodo-app/src/layouts/authorities/CoverageMap/index.js
+++ b/modules/periodo-app/src/layouts/authorities/CoverageMap/index.js
@@ -1,28 +1,105 @@
 "use strict";
 
 const h = require('react-hyperscript')
-    , { WorldMap } = require('periodo-ui')
+    , { useState } = require('react')
+    , { Box, LabeledMap, PlaceSuggest, Tags } = require('periodo-ui')
 
-const CoverageMap = ({ data: periods, gazetteers }) => {
-  const featureSet = periods.reduce(
-    (featureSet, period) => {
-      (period.spatialCoverage || [])
-        .map(({ id }) => gazetteers.find(id))
-        .filter(feature => feature !== null)
-        .forEach(feature => featureSet.add(feature))
-      return featureSet
-    },
-    new Set()
-  )
-  return h(WorldMap, {
-    height: 256,
-    border: '1px solid #ccc',
-    features: [ ...featureSet ],
-  })
+const allFeatures = (periods, gazetteers) => periods.reduce(
+  (featuresById, period) => {
+    (period.spatialCoverage || [])
+      .map(({ id }) => gazetteers.find(id))
+      .filter(feature => feature && feature.id
+              && !(featuresById.hasOwnProperty(feature.id)))
+      .forEach(feature => featuresById[feature.id] = feature)
+    return featuresById
+  },
+  {}
+)
+
+const accepts = (filter, item) => {
+  if (!filter) return true
+  return item && item.id && filter.hasOwnProperty(item.id)
+}
+
+const toggle = (filter, item) => {
+  if (!item || !item.id) return filter
+  const newFilter = { ...(filter || {}) }
+  if (newFilter.hasOwnProperty(item.id)) {
+    delete newFilter[item.id]
+  } else {
+    newFilter[item.id] = item
+  }
+  return (Object.keys(newFilter).length === 0)
+    ? null
+    : newFilter
+}
+
+const CoverageMap = ({ opts, updateOpts, data: periods, gazetteers }) => {
+
+  const { filter } = opts
+
+  const [ focusedFeature, setFocusedFeature ] = useState(undefined)
+
+  return h(Box, {
+    mt: 2,
+  }, [
+    filter
+      ? h(Tags,
+        {
+          items: Object.values(filter),
+          getItemLabel: feature => feature.properties.title,
+          onFocus: feature => setFocusedFeature(feature),
+          onBlur: () => setFocusedFeature(undefined),
+          onDelete: feature => updateOpts({
+            ...opts,
+            filter: toggle(filter, feature),
+          }, true),
+        })
+      : h(Box,
+        {
+          height: '24px',
+          color: 'gray.6',
+          css: {
+            lineHeight: '24px',
+            fontStyle: 'italic',
+          },
+        }, 'Showing all places. Search below for places to filter by'),
+
+    h(LabeledMap, {
+      focusedFeature,
+      features: Object.values(filter || allFeatures(periods, gazetteers)),
+      mt: 1,
+    }),
+
+    h(PlaceSuggest, {
+      gazetteers,
+      onSuggestionHighlighted:
+        ({ suggestion }) => setFocusedFeature(suggestion),
+      isSelected: feature => filter ? accepts(filter, feature) : false,
+      onSelect: feature => updateOpts({
+        ...opts,
+        filter: toggle(filter, feature),
+      }, true),
+    }),
+  ])
 }
 
 module.exports = {
   label: 'Spatial coverage map',
   description: 'WebGL map showing spatial coverage of selected periods',
+  makeFilter(opts) {
+
+    const filter = opts && opts.filter
+
+    if (!filter) return null
+
+    return period => {
+      if (!period.spatialCoverage) return false
+      for (const item of period.spatialCoverage) {
+        if (accepts(filter, item)) return true
+      }
+      return false
+    }
+  },
   Component: CoverageMap,
 }

--- a/modules/periodo-app/src/layouts/authorities/blocks.js
+++ b/modules/periodo-app/src/layouts/authorities/blocks.js
@@ -7,6 +7,7 @@ module.exports = {
   'authority-list': require('./AuthorityList'),
   'time-cutoff': require('./HumanTimeCheckmark'),
   'timespan-visualization': require('./Timeline'),
+  'spatial-visualization': require('./CoverageMap'),
   'facets': require('./Facets'),
   'period-detail': require('./PeriodDetail'),
   'authority-detail': require('./AuthorityDetail'),

--- a/modules/periodo-ui/src/FeatureLabel.js
+++ b/modules/periodo-ui/src/FeatureLabel.js
@@ -2,7 +2,9 @@
 
 const h = require('react-hyperscript')
     , R = require('ramda')
-    , { Box, Text, Heading, Italic, InlineList } = require('periodo-ui')
+    , { Box, Text, Heading } = require('./Base')
+    , { Italic } = require('./Typography')
+    , { InlineList } = require('./InlineList')
 
 const otherNames = feature => feature.names
   ? feature.names
@@ -17,7 +19,7 @@ const description = feature => feature.descriptions
       .join('; ')
   : ''
 
-const FeatureLabel = ({ feature, ...props }) => {
+exports.FeatureLabel = ({ feature, ...props }) => {
   const show = feature && feature.properties && feature.properties.title
   return h(Box, {
     p: show ? 2 : 0,
@@ -47,5 +49,3 @@ const FeatureLabel = ({ feature, ...props }) => {
     : []
   )
 }
-
-module.exports = FeatureLabel

--- a/modules/periodo-ui/src/LabeledMap.js
+++ b/modules/periodo-ui/src/LabeledMap.js
@@ -1,10 +1,11 @@
 "use strict";
 
 const h = require('react-hyperscript')
-    , { Flex, WorldMap } = require('periodo-ui')
-    , FeatureLabel = require('./FeatureLabel')
+    , { Flex } = require('./Base')
+    , { WorldMap } = require('./WorldMap')
+    , { FeatureLabel } = require('./FeatureLabel')
 
-const LabeledMap = ({ focusedFeature, features, ...props }) => h(Flex, {
+exports.LabeledMap = ({ focusedFeature, features, ...props }) => h(Flex, {
   border: '1px solid #ccc',
   borderBottom: 'none',
   ...props,
@@ -22,5 +23,3 @@ const LabeledMap = ({ focusedFeature, features, ...props }) => h(Flex, {
     css: { transition: 'width 0.25s' },
   }),
 ])
-
-module.exports = LabeledMap

--- a/modules/periodo-ui/src/PlaceSuggest.js
+++ b/modules/periodo-ui/src/PlaceSuggest.js
@@ -2,7 +2,8 @@
 
 const h = require('react-hyperscript')
     , R = require('ramda')
-    , { Box, Span, Autosuggest } = require('periodo-ui')
+    , { Box, Span } = require('./Base')
+    , { Autosuggest } = require('./Autosuggest')
 
 const escapeRegexCharacters = str => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 
@@ -85,7 +86,7 @@ const renderSuggestion = (item, { isHighlighted, isSelected }) => h(Box,
   ]
 )
 
-const PlaceSuggest = ({
+exports.PlaceSuggest = ({
   gazetteers,
   onSuggestionHighlighted,
   isSelected,
@@ -126,10 +127,9 @@ const PlaceSuggest = ({
     inputProps: {
       id: 'coverage-area',
       border: 'none',
+      placeholder: 'Begin typing to search for places',
     },
     onSuggestionHighlighted,
     onSelect,
   }),
 ])
-
-module.exports = PlaceSuggest

--- a/modules/periodo-ui/src/Tags.js
+++ b/modules/periodo-ui/src/Tags.js
@@ -33,6 +33,8 @@ const Tag = ({ label, onDelete, ...props }) => h(Box, {
 // items must have { id, label }
 const Tags = ({
   items,
+  getItemKey = item => item.id,
+  getItemLabel = item => item.label,
   onFocus,
   onBlur,
   onDelete,
@@ -57,8 +59,8 @@ const Tags = ({
     css: { listStyleType: 'none' },
     ...props,
   }, items.map((item, index) => h(Tag, {
-    key: item.id,
-    label: item.label,
+    key: getItemKey(item),
+    label: getItemLabel(item),
     mr: 1,
     mb: 1,
     onFocus: () => {

--- a/modules/periodo-ui/src/WorldMap.js
+++ b/modules/periodo-ui/src/WorldMap.js
@@ -242,24 +242,26 @@ const _Map = ({ features=[], focusedFeature, height }) => {
   const innerRef = useRef()
       , outerRef = useRef()
       , width = useRect(outerRef).width
-      , map = initializeMap(mix)
-
-  renderMix()
-
-  const mapNode = map.render({
-    width,
-    height,
-  })
-
-  map.display(features, focusedFeature)
+      , featureIds = features.map(feature => feature.id).join('|')
+      , focusedFeatureId = focusedFeature ? focusedFeature.id : null
 
   useLayoutEffect(() => {
+    renderMix()
+
+    const map = initializeMap(mix)
+    const mapNode = map.render({
+      width,
+      height,
+    })
+    map.display(features, focusedFeature)
+
     const parent = innerRef.current
     const child = parent.appendChild(mapNode)
+
     return function cleanup() {
       parent.removeChild(child)
     }
-  }, [ mapNode, features, focusedFeature ])
+  }, [ featureIds, focusedFeatureId, height, width ])
 
   return h('div', {
     ref: outerRef,

--- a/modules/periodo-ui/src/index.js
+++ b/modules/periodo-ui/src/index.js
@@ -33,4 +33,6 @@ addUIModules([
   require('./WorldMap'),
   require('./Tags'),
   require('./BackendContext'),
+  require('./LabeledMap'),
+  require('./PlaceSuggest'),
 ])

--- a/modules/periodo-ui/src/useRect.js
+++ b/modules/periodo-ui/src/useRect.js
@@ -42,7 +42,7 @@ module.exports = ref => {
         window.removeEventListener('resize', debouncedHandler)
       }
     }
-  }, [ ref.current ])
+  }, [ ref ])
 
   return rect
 }


### PR DESCRIPTION
Adds a map visualization of the combined rough spatial coverage of the set of unique Wikidata entities associated with the current set of periods.

Would be more useful in conjunction with a new facet over spatial coverage entities (as opposed to spatial coverage descriptions), but I will work on that in a separate branch.