### PR TITLE
Add file backends back in

### DIFF
--- a/modules/periodo-app/package.json
+++ b/modules/periodo-app/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^16.2.0",
     "react-geomicons": "^2.1.0",
     "react-hyperscript": "github:periodo/react-hyperscript",
-    "react-redux": "^5.0.6",
+    "react-redux": "^7.1.0",
     "react-window": "^1.8.3",
     "redux": "^3.7.2",
     "redux-thunk": "^2.2.0",

--- a/modules/periodo-app/src/backends/components/AddBackend.js
+++ b/modules/periodo-app/src/backends/components/AddBackend.js
@@ -12,11 +12,17 @@ const AddBackend = props =>
     h(ResourceTitle, 'Add backend'),
     h(BackendForm, {
       handleSave: async state => {
-        const { label, description='', type } = state
+        const { label, description='', type, file } = state
 
-        const storage = type === 'Web'
-          ? BackendStorage.WebOf(state)
-          : BackendStorage.IndexedDB(null)
+        let storage
+
+        if (type === 'Web') {
+          storage = BackendStorage.WebOf(state)
+        } else if (type === 'IndexedDB') {
+          storage = BackendStorage.IndexedDB(null)
+        } else if (type === 'StaticFile') {
+          storage = BackendStorage.StaticFile(null, file)
+        }
 
         const resp = await props.dispatch(
           BackendAction.CreateBackend(storage, label, description))

--- a/modules/periodo-app/src/backends/components/BackendSelect.js
+++ b/modules/periodo-app/src/backends/components/BackendSelect.js
@@ -46,6 +46,7 @@ module.exports = props =>
               IndexedDB: () => 'Local',
               Memory: () => 'Memory',
               Canonical: () => 'Web',
+              StaticFile: () => 'File',
             })),
             h('td', [
               h(Link, {

--- a/modules/periodo-app/src/backends/reducer.js
+++ b/modules/periodo-app/src/backends/reducer.js
@@ -47,6 +47,10 @@ module.exports = function backends(state=initialState(), action) {
         )
       },
 
+      GetFileStorage() {
+        return state
+      },
+
       GetBackendDataset() {
         const { backend, dataset } = resp
 

--- a/modules/periodo-app/src/backends/types.js
+++ b/modules/periodo-app/src/backends/types.js
@@ -5,15 +5,22 @@ const Type = require('union-type')
 
 const BackendStorage = Type({
   Web: { url: isURL },
-  IndexedDB: { id: x => x === null || Number.isInteger(x) },
+  IndexedDB: {
+    id: x => x === null || Number.isInteger(x),
+  },
+  StaticFile: {
+    id: x => x === null || Number.isInteger(x),
+    file: x => x instanceof File,
+  },
   Memory: {},
   Canonical: {},
 })
 
 BackendStorage.prototype.asIdentifier = function () {
   return this.case({
-    IndexedDB: id => `local-${id}`,
     Web: url => `web-${url}`,
+    IndexedDB: id => `local-${id}`,
+    StaticFile: id => `file-${id}`,
     _: () => {
       throw new Error('not yet')
     },
@@ -37,6 +44,9 @@ BackendStorage.fromIdentifier = identifier => {
 
   case 'local':
     return BackendStorage.IndexedDB(parseInt(id));
+
+  case 'file':
+    throw new Error('Cannot create StaticFile storage objects through this constructor')
 
   default:
     throw new Error(`Unknown backend type: ${type}`)

--- a/modules/periodo-app/src/db/index.js
+++ b/modules/periodo-app/src/db/index.js
@@ -12,6 +12,7 @@ module.exports = function periodoDB(dexieOpts) {
   require('./version-02')(db)
   require('./version-03')(db)
   require('./version-04')(db)
+  require('./version-05')(db)
 
   db.on('populate', () => {
     if (globals.periodoServerURL) {

--- a/modules/periodo-app/src/db/version-05.js
+++ b/modules/periodo-app/src/db/version-05.js
@@ -1,0 +1,36 @@
+"use strict";
+
+module.exports = function dbVersion2(db) {
+  db.version(4).stores({
+    localBackends: `
+      ++id,
+      created,
+      modified,
+      accessed
+    `,
+
+    remoteBackends: 'url',
+
+    fileBackends: '++id',
+
+    settings: `++id`,
+
+    // Patches derived from changes in IDB backends
+    localBackendPatches: `
+      ++id,
+      backendID,
+      created,
+      *changeType,
+      *affectedAuthorities,
+      *affectedPeriods,
+      *forwardHashes,
+      *backwardHashes
+    `,
+
+    // Patches submitted from a local dataset
+    patchSubmissions: 'patchURL, backendID, resolved',
+
+    // Cached triples from URLs
+    linkedDataCache: 'url, *triples.subject, *triples.object',
+  })
+}

--- a/modules/periodo-app/src/main/Application.js
+++ b/modules/periodo-app/src/main/Application.js
@@ -6,7 +6,7 @@ const h = require('react-hyperscript')
     , { ORGShell, Route } = require('org-shell')
     , { Flex, Pre, Box, Grid, Heading, theme } = require('periodo-ui')
     , { Link } = require('periodo-ui')
-    , { Provider, connect } = require('react-redux')
+    , { Provider } = require('react-redux')
     , { ThemeProvider } = require('styled-components')
     , createStore = require('../store')
     , resources = require('../resources')
@@ -15,10 +15,8 @@ const h = require('react-hyperscript')
 
 require('./global_css')
 
-function getRouteGroups(resource, { params }) {
+function getRouteGroups(resource, props) {
   const hierarchy = resource.hierarchy || resources[''].hierarchy
-
-  const props = { params }
 
   try {
     return hierarchy.slice(0, -1).map(group => ({
@@ -27,7 +25,7 @@ function getRouteGroups(resource, { params }) {
         (acc, [ routeName, resource ]) =>
           (resource.showInMenu || R.T)(props)
             ? [ ...acc, {
-              route: new Route(routeName, params),
+              route: new Route(routeName, props.params),
               label: resource.label,
             }]
             : acc
@@ -104,8 +102,6 @@ class Menu extends React.Component {
   }
 }
 
-const WrappedMenu = connect(state => ({ storeState: state }))(Menu)
-
 class MenuedResource extends React.Component{
   constructor() {
     super();
@@ -120,7 +116,7 @@ class MenuedResource extends React.Component{
 
     return (
       h(Box, [
-        h(WrappedMenu, {
+        h(Menu, {
           loading: this.props.loading,
           activeResource: this.props.activeResource,
           params: this.props.params,


### PR DESCRIPTION
Involved a lot of shuffling around due to the fact that
BackendStorage.StaticFile cannot be constructed with just a string.

I could have made it the same as BackendStorage.IndexedDB, but it would
have required adding a third argument to the CreateBackend action to
allow the file to be submitted at the same time as the newly created
StaticFile backend. The IndexedDB backend storage does not have the same
problem because it always starts as an empty dataset.