### PR TITLE
New authority layout

### DIFF
--- a/modules/periodo-app/src/backends/components/Authority.js
+++ b/modules/periodo-app/src/backends/components/Authority.js
@@ -121,7 +121,11 @@ module.exports = class AuthorityLayout extends React.Component {
         }),
       ]),
 
-      h(Text, { mb: 3 },
+      h(Text,
+        {
+          mb: 3,
+          maxWidth: '60em',
+        },
         h(LinkifiedTextValue, {
           value: { text: description.editorialNote },
         })

--- a/modules/periodo-app/src/backends/components/Authority.js
+++ b/modules/periodo-app/src/backends/components/Authority.js
@@ -1,56 +1,145 @@
 "use strict";
 
 const h = require('react-hyperscript')
+    , R = require('ramda')
     , React = require('react')
-    , { Flex, Box, Heading } = require('periodo-ui')
-    , { Authority } = require('periodo-ui')
+    , { Heading, Box, Span, Text } = require('periodo-ui')
+    , { PermalinkValue, LinkifiedTextValue } = require('periodo-ui')
+    , { authority: { describe }} = require('periodo-utils')
     , AuthorityLayoutRenderer = require('../../layouts/authorities')
-    , DatasetProxy = require('../dataset_proxy')
+    , debounce = require('debounce')
 
-const layout = `
-[]
-type = period-list
+const authorityLayout = `
+grid-template-columns = repeat(6, 1fr)
+grid-template-rows = repeat(6, auto)
+grid-gap = 1em 1.66em
+
+[Search]
+type = text-search
+grid-column = 1/7
+grid-row = 1/2
+
+[PlaceFilter]
+type = place-filter
+grid-column = 1/7
+grid-row = 2/3
+
+[Facets]
+type = facets
+flex = true
+height = 156
+grid-column = 1/7
+grid-row = 3/4
+
+[SpatialCoverage]
+type = spatial-visualization
+grid-column = 4/7
+grid-row = 4/5
+
+[TimeRange]
+type = timespan-visualization
+grid-column = 1/4
+grid-row = 4/5
+height = 200
+
+[PeriodList]
+type = windowed-period-list
+grid-column = 1/7
+grid-row = 5/6
+
+[PeriodDetail]
+type = period-detail
+grid-column = 1/4
+grid-row = 6/7
+
+[AuthorityDetail]
+type = authority-detail
+grid-column = 4/7
+grid-row = 6/7
 `
 
-class AuthorityLayout extends React.Component {
-  constructor() {
-    super()
-    this.state = { blockOpts: {}}
+module.exports = class AuthorityLayout extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      blockOpts: this.props.opts.Layout || {
+        Facets: {
+          selected: { authority: [ props.authority.id ]},
+          hidden: [ 'authority' ],
+          flexBasis: {
+            language: '33%',
+            spatialCoverage: '67%',
+          },
+        },
+      },
+    }
+
+    this.persistBlockOpts = debounce(this.persistBlockOpts.bind(this), 50)
+  }
+
+  persistBlockOpts() {
+    const { updateOpts } = this.props
+        , { blockOpts } = this.state
+
+    R.isEmpty(blockOpts)
+      ? updateOpts(R.dissoc('Layout'))
+      : updateOpts(R.set(R.lensProp('Layout'), blockOpts))
   }
 
   render() {
-    const { backend, authority } = this.props
+    const { backend, dataset, authority, gazetteers } = this.props
+        , { blockOpts } = this.state
 
-    return (
-      h(AuthorityLayoutRenderer, {
-        layout,
-        backend,
-        dataset: new DatasetProxy({
-          authorities: {
-            [authority.id]: authority,
-          },
+    const childProps = {
+      backend,
+      dataset,
+      gazetteers,
+      blockOpts,
+      onBlockOptsChange: updatedOpts => {
+        this.setState({ blockOpts: updatedOpts }, this.persistBlockOpts)
+      },
+    }
+
+    const description = describe(authority)
+
+    return h(Box, [
+      h(Heading, {
+        level: 2,
+        mb: 2,
+      }, description.source),
+
+      h(Box, { mb:2 }, [
+        h(Span, {
+          fontSize: 3,
+          color: 'gray.6',
+        }, 'Permalink: '),
+
+        h(PermalinkValue, {
+          value: description.id,
+          fontSize: 3,
         }),
-        blockOpts: this.state.blockOpts,
-        onBlockOptsChange: blockOpts => this.setState({ blockOpts }),
-      })
-    )
+      ]),
+
+      h(Text, { mb: 3 },
+        h(LinkifiedTextValue, {
+          value: { text: description.editorialNote },
+        })
+      ),
+
+      description.periods === 0
+        ? (
+          h(Box, {
+            fontSize: 4,
+            color: 'gray.8',
+          }, 'No periods in this authority.')
+        )
+        : (
+          h(AuthorityLayoutRenderer, {
+            ...childProps,
+            layout: authorityLayout,
+          })
+        ),
+    ])
   }
 }
-
-module.exports = ({ backend, authority }) =>
-  h(Flex, [
-    h(Box, { width: .5 }, [
-      h(Heading, { level: 2 }, 'Authority'),
-
-      h(Authority, { value: authority }),
-    ]),
-
-    h(Box, { width: .5 }, [
-      h(Heading, { level: 2 }, 'Periods'),
-
-      h(AuthorityLayout, {
-        backend,
-        authority,
-      }),
-    ]),
-  ])

--- a/modules/periodo-app/src/backends/components/BackendHome.js
+++ b/modules/periodo-app/src/backends/components/BackendHome.js
@@ -70,7 +70,15 @@ module.exports = class BackendHome extends React.Component {
       // layout: defaultLayout,
       // editingLayout: defaultLayout,
       // showEdit: false,
-      blockOpts: this.props.opts.Layout || {},
+      blockOpts: this.props.opts.Layout || {
+        Facets: {
+          flexBasis: {
+            authority: '50%',
+            language: '25%',
+            spatialCoverage: '25%',
+          },
+        },
+      },
     }
 
     this.persistBlockOpts = debounce(this.persistBlockOpts.bind(this), 50)

--- a/modules/periodo-app/src/layouts/authorities/Facets/index.js
+++ b/modules/periodo-app/src/layouts/authorities/Facets/index.js
@@ -32,6 +32,12 @@ function intersection(...sets) {
 
 
 const aspects = {
+  authority: {
+    label: 'Authority',
+    getter: period => authorityOf(period).id,
+    render: identityWithDefault('(no value)'),
+  },
+
   language: {
     label: 'Language',
     getter: period => languageDescription(period.languageTag),
@@ -41,12 +47,6 @@ const aspects = {
   spatialCoverage: {
     label: 'Spatial coverage',
     getter: period => period.spatialCoverageDescription || null,
-    render: identityWithDefault('(no value)'),
-  },
-
-  authority: {
-    label: 'Authority',
-    getter: period => authorityOf(period).id,
     render: identityWithDefault('(no value)'),
   },
 }
@@ -93,7 +93,13 @@ class AspectTable extends React.Component {
         , render = aspect.render || R.identity
         , height = parseInt(opts.height || '256')
 
+    const hidden = new Set(opts.hidden|| [])
     const selected = new Set(R.path([ 'selected', aspectID ], opts) || [])
+    const flexBasis = R.path([ 'flexBasis', aspectID ], opts) || '0%'
+
+    if (hidden.has(aspectID)) {
+      return null
+    }
 
     const selectedRows = []
         , unselectedRows = []
@@ -144,6 +150,7 @@ class AspectTable extends React.Component {
       h(Flex, {
         style: {
           flex: 1,
+          flexBasis,
         },
         flexDirection: 'column',
         border: 1,

--- a/modules/periodo-app/src/layouts/authorities/WindowedPeriodList.js
+++ b/modules/periodo-app/src/layouts/authorities/WindowedPeriodList.js
@@ -399,7 +399,7 @@ class PeriodList extends React.Component {
 }
 
 PeriodList.defaultProps = {
-  sortBy: 'label',
+  sortBy: 'start',
   sortDirection: 'asc',
 }
 

--- a/modules/periodo-app/src/resources.js
+++ b/modules/periodo-app/src/resources.js
@@ -512,6 +512,33 @@ const Authority = {
     'authority-view': {
       label: 'View',
       Component: require('./backends/components/Authority'),
+      async loadData(props, log, finished) {
+        const { dispatch, getState } = props
+            , storage = getCurrentBackendStorage(props)
+
+        const gazetteers = log('Loading gazetteers', throwIfUnsuccessful(
+          dispatch(GraphsAction.FetchGazetteers)))
+
+        const dataset = R.path([
+          'backends',
+          'datasets',
+          storage.asIdentifier(),
+        ], getState())
+
+        const sorts = log('Initializing sorts', Promise.all([
+          dataset.cachedSort([], 'label'),
+          dataset.cachedSort([], 'start'),
+        ]))
+
+        await Promise.all([ gazetteers, sorts ])
+
+        finished()
+      },
+      mapStateToProps(state) {
+        return {
+          gazetteers: state.graphs.gazetteers,
+        }
+      },
     },
 
     'authority-edit': {

--- a/modules/periodo-ui/src/index.js
+++ b/modules/periodo-ui/src/index.js
@@ -37,4 +37,5 @@ addUIModules([
   require('./LabeledMap'),
   require('./PlaceSuggest'),
   require('./PlacesSelect'),
+  require('./diffable/Value'),
 ])

--- a/modules/periodo-utils/src/authority.js
+++ b/modules/periodo-utils/src/authority.js
@@ -28,8 +28,9 @@ function describe(authority) {
     id: authority.id,
     source: displayTitle(authority),
     periods: periods.length,
-    earliest: terminusList.minYear(R.map(R.path(['start']))(periods)),
-    latest: terminusList.maxYear(R.map(R.path(['stop']))(periods)),
+    earliest: terminusList.minYear(R.map(R.path([ 'start' ]))(periods)),
+    latest: terminusList.maxYear(R.map(R.path([ 'stop' ]))(periods)),
+    editorialNote: authority.editorialNote || '',
   }
 }
 
@@ -50,7 +51,7 @@ function asCSV(authority) {
       'latest_stop': getLatestYear(stop),
       'spatialCoverages': (period.spatialCoverage || []).map(sc => sc.id).join('|'),
       'note': period.get('note'),
-      'editorial_note': period.get('editorialNote')
+      'editorial_note': period.get('editorialNote'),
     }
   }))
 }


### PR DESCRIPTION
This sets up a layout for the authority view close to the same as the backend browse view, the sole differences being that the authority facet is hidden, and the authority title / link / notes appear at the top.

Also includes some adjustments to the default facet view in the backend browse: authority facet comes first and is wider.