### PR TITLE
new layout for period view showing it in context of its authority

### DIFF
--- a/modules/periodo-app/src/backends/components/Authority.js
+++ b/modules/periodo-app/src/backends/components/Authority.js
@@ -113,7 +113,7 @@ module.exports = class AuthorityLayout extends React.Component {
         h(Span, {
           fontSize: 3,
           color: 'gray.6',
-        }, 'Permalink: '),
+        }, 'Permalink '),
 
         h(PermalinkValue, {
           value: description.id,

--- a/modules/periodo-app/src/backends/components/PeriodView.js
+++ b/modules/periodo-app/src/backends/components/PeriodView.js
@@ -1,13 +1,148 @@
 "use strict";
 
 const h = require('react-hyperscript')
-    , { Box } = require('periodo-ui')
-    , { Period } = require('periodo-ui')
+    , R = require('ramda')
+    , React = require('react')
+    , { Box, Span, Heading, Text } = require('periodo-ui')
+    , { PermalinkValue, LinkifiedTextValue } = require('periodo-ui')
+    , { RelatedAuthorityValue } = require('periodo-ui')
+    , { permalink } = require('periodo-utils')
+    , AuthorityLayoutRenderer = require('../../layouts/authorities')
+    , debounce = require('debounce')
 
-module.exports = ({ period, gazetteers }) =>
-  h(Box, [
-    h(Period, {
-      value: period,
+const periodLayout = `
+grid-template-columns = repeat(6, 1fr)
+grid-template-rows = repeat(5, auto)
+grid-gap = 1em 1.66em
+
+[Facets]
+type = facets
+flex = true
+height = 156
+grid-column = 1/7
+grid-row = 1/2
+
+[SpatialCoverage]
+type = spatial-visualization
+grid-column = 4/7
+grid-row = 2/3
+
+[TimeRange]
+type = timespan-visualization
+grid-column = 1/4
+grid-row = 2/3
+height = 200
+
+[PeriodList]
+type = windowed-period-list
+grid-column = 1/7
+grid-row = 3/4
+
+[PeriodDetail]
+type = period-detail
+grid-column = 1/4
+grid-row = 4/5
+
+[AuthorityDetail]
+type = authority-detail
+grid-column = 4/7
+grid-row = 4/5
+`
+
+function EditorialNote({ text, ...props }) {
+  return h(Text,
+    {
+      mb: 3,
+      maxWidth: '60em',
+      ...props,
+    },
+    h(LinkifiedTextValue, {
+      value: { text },
+    })
+  )
+}
+
+function Note({ cite, ...props }) {
+  return EditorialNote({
+    is: 'blockquote',
+    cite,
+    ...props,
+  })
+}
+
+module.exports = class PeriodLayout extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      blockOpts: this.props.opts.Layout || {
+        Facets: {
+          selected: { authority: [ props.authority.id ]},
+          hidden: [ 'authority', 'language', 'spatialCoverage' ],
+        },
+      },
+    }
+
+    this.persistBlockOpts = debounce(this.persistBlockOpts.bind(this), 50)
+  }
+
+  persistBlockOpts() {
+    const { updateOpts } = this.props
+        , { blockOpts } = this.state
+
+    R.isEmpty(blockOpts)
+      ? updateOpts(R.dissoc('Layout'))
+      : updateOpts(R.set(R.lensProp('Layout'), blockOpts))
+  }
+
+  render() {
+    const { backend, dataset, authority, period, gazetteers } = this.props
+        , { blockOpts } = this.state
+
+    const childProps = {
+      backend,
+      dataset,
       gazetteers,
-    }),
-  ])
+      blockOpts,
+      onBlockOptsChange: updatedOpts => {
+        this.setState({ blockOpts: updatedOpts }, this.persistBlockOpts)
+      },
+    }
+
+    return h(Box, [
+      h(Heading, {
+        level: 2,
+        mb: 2,
+      }, period.label),
+
+      h(Box, {
+        mb: 2,
+        fontSize: 3,
+      }, [
+        h(Span, { color: 'gray.6' }, 'Permalink '),
+        h(PermalinkValue, { value: period.id }),
+      ]),
+
+      h(Box, {
+        mb: 2,
+        fontSize: 3,
+      }, [
+        h(Span, { color: 'gray.6' }, 'Defined by '),
+        h(RelatedAuthorityValue, { value: authority }),
+      ]),
+
+      h(Note, {
+        text: period.note || '',
+        cite: permalink(authority),
+      }),
+
+      h(EditorialNote, { text: period.editorialNote || '' }),
+
+      h(AuthorityLayoutRenderer, {
+        ...childProps,
+        layout: periodLayout,
+        fixedPeriod: period,
+      }),
+    ])
+  }
+}

--- a/modules/periodo-app/src/layouts/authorities/WindowedPeriodList.js
+++ b/modules/periodo-app/src/layouts/authorities/WindowedPeriodList.js
@@ -272,19 +272,18 @@ class PeriodList extends React.Component {
         , column = columns[sortBy]
 
     if (column) {
+      let sortedData = null
+
       if (column.sort) {
-        const sortedData = await column.sort(data, this.props)
-        this.setState({
-          sortedData,
-          start: 0,
-        })
+        sortedData = await column.sort(data, this.props)
+
       } else {
         const sorter = natsort({
           insensitive: true,
           desc: sortDirection === 'desc',
         })
 
-        const sortedData = [ ...data ].sort((a, b) => {
+        sortedData = [ ...data ].sort((a, b) => {
           const [ _a, _b ] = [ a, b ].map(column.getValue)
 
           if (_a == null) return 1
@@ -292,11 +291,17 @@ class PeriodList extends React.Component {
 
           return sorter(_a, _b)
         })
+      }
 
-        this.setState({
-          sortedData,
-          start: 0,
-        })
+      this.setState({
+        sortedData,
+        start: 0,
+      })
+
+      if (this.props.fixedPeriod && this.listRef.current) {
+        this.listRef.current.scrollToItem(
+          sortedData.findIndex(({ id }) => id === this.props.fixedPeriod.id) + 4
+        )
       }
     }
   }

--- a/modules/periodo-app/src/layouts/authorities/index.js
+++ b/modules/periodo-app/src/layouts/authorities/index.js
@@ -7,9 +7,15 @@ const h = require('react-hyperscript')
     , { Navigable } = require('org-shell')
     , blocks = require('./blocks')
 
-module.exports = Navigable((props) => {
-  const [ hoveredPeriod, setHoveredPeriod ] = useState(null)
-      , [ selectedPeriod, setSelectedPeriod ] = useState(null)
+module.exports = Navigable(({ fixedPeriod, ...props }) => {
+
+  const [ hoveredPeriod, setHoveredPeriod ] = fixedPeriod
+    ? [ null, () => {} ]
+    : useState(null)
+
+  const [ selectedPeriod, setSelectedPeriod ] = fixedPeriod
+    ? [ fixedPeriod, () => {} ]
+    : useState(null)
 
   const data = props.useAuthorities
     ? props.dataset.authorities
@@ -29,6 +35,7 @@ module.exports = Navigable((props) => {
         setHoveredPeriod,
         selectedPeriod,
         setSelectedPeriod,
+        fixedPeriod,
       },
     }))
   )

--- a/modules/periodo-ui/src/diffable/Value.js
+++ b/modules/periodo-ui/src/diffable/Value.js
@@ -12,7 +12,6 @@ const h = require('react-hyperscript')
     , { BackendContext } = require('../BackendContext')
     , { useContext } = require('react')
     , linkifier = require('linkify-it')()
-    , { permalinkURL } = require('../../../periodo-app/src/globals')
     , util = require('periodo-utils')
     , styled = require('styled-components').default
 
@@ -114,10 +113,12 @@ function LinkValue(props) {
 function PermalinkValue(props) {
   const { value } = props
 
-  if (value.startsWith('p0')) {
+  const permalink = util.permalink({ id: value })
+
+  if (permalink) {
     const childProps = {
       ...props,
-      value: `${ permalinkURL }${ value }`,
+      value: permalink,
     }
 
     return LinkValue(childProps)
@@ -140,6 +141,22 @@ function RelatedPeriodValue(props) {
 
   return (
     h(Link, childProps, period.label)
+  )
+}
+
+function RelatedAuthorityValue(props) {
+  const { value: authority } = props
+      , { backend } = useContext(BackendContext)
+
+  const childProps = {
+    route: Route('authority-view', {
+      backendID: backend.asIdentifier(),
+      authorityID: authority.id,
+    }),
+  }
+
+  return (
+    h(Link, childProps, util.authority.displayTitle(authority))
   )
 }
 
@@ -349,4 +366,5 @@ module.exports = {
   SpatialExtentValue,
   JSONLDContextValue,
   RelatedPeriodValue,
+  RelatedAuthorityValue,
 }

--- a/modules/periodo-utils/src/period.js
+++ b/modules/periodo-utils/src/period.js
@@ -9,7 +9,10 @@ function originalLabel(period) {
 
   if (!label || !languageTag) return null;
 
-  return { label, languageTag }
+  return {
+    label,
+    languageTag,
+  }
 }
 
 const allLabels = period =>
@@ -18,14 +21,17 @@ const allLabels = period =>
     R.pipe(
       R.propOr({}, 'localizedLabels'),
       R.mapObjIndexed((labels, languageTag) =>
-        labels.map(label => ({ label, languageTag }))),
+        labels.map(label => ({
+          label,
+          languageTag,
+        }))),
       R.values,
       R.unnest
     )(period)
   )
 
 function alternateLabels(period) {
-  return R.without([originalLabel(period)], allLabels(period))
+  return R.without([ originalLabel(period) ], allLabels(period))
 }
 
 function authorityOf(period) {
@@ -34,7 +40,7 @@ function authorityOf(period) {
 
 function periodWithAuthority(period) {
   return {
-    period: R.path([$$Authority, 'periods', period.id], period),
+    period: R.path([ $$Authority, 'periods', period.id ], period),
     authority: authorityOf(period),
   }
 }

--- a/modules/periodo-utils/src/util.js
+++ b/modules/periodo-utils/src/util.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const R = require('ramda')
+    , { permalinkURL } = require('../../periodo-app/src/globals')
 
 function oneOf(...candidates) {
   return x => {
@@ -17,8 +18,13 @@ const valueAsArray = R.curry(
   (prop, obj) => ensureArray(R.propOr([], prop, obj))
 )
 
+const permalink = ({ id }) => id && id.startsWith('p0')
+  ? `${ permalinkURL }${ id }`
+  : null
+
 module.exports = {
   oneOf,
   ensureArray,
   valueAsArray,
+  permalink,
 }


### PR DESCRIPTION
This sets up a layout for the period view close to the same as the authority view, except that:

1) the facets are hidden
2) the period label / link / notes appear at the top
3) the selected period in the period list is fixed