### PR TITLE
Looser parsing of WorldCat URLs

### DIFF
--- a/modules/periodo-app/src/linked-data/test/source_ld_match.js
+++ b/modules/periodo-app/src/linked-data/test/source_ld_match.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const test = require('blue-tape')
+    , { match, asURL } = require('../utils/source_ld_match')
+
+test('Parsing WorldCat URLs', async t => {
+
+  t.equal(asURL(match("http://worldcat.org/oclc/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("http://www.worldcat.org/oclc/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("https://worldcat.org/en/title/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("https://worldcat.org/ja/title/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("https://worldcat.org/oclc/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("https://worldcat.org/title/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+  t.equal(asURL(match("https://www.worldcat.org/oclc/228741004")), "http://experiment.worldcat.org/oclc/228741004.ttl")
+})

--- a/modules/periodo-app/src/linked-data/utils/source_ld_match.js
+++ b/modules/periodo-app/src/linked-data/utils/source_ld_match.js
@@ -4,7 +4,7 @@ const R = require('ramda')
     , doi = require('identifiers-doi')
     , Type = require('union-type')
 
-const worldcatUrlRegex = /worldcat.org\/.*?oclc\/(\d+).*/i
+const worldcatUrlRegex = /worldcat.org\/(?:[a-z]+\/)?(?:oclc|title)\/(\d+).*/i
 
 const Identifier = Type({
   Worldcat: {


### PR DESCRIPTION
WorldCat no longer provides useful permalinks, so we need to handle their variety of URLs to fix source parsing.