### PR TITLE
Authority form bug fixes

### DIFF
--- a/modules/periodo-app/src/forms/AuthorityForm/NonLDSourceForm.js
+++ b/modules/periodo-app/src/forms/AuthorityForm/NonLDSourceForm.js
@@ -29,7 +29,7 @@ module.exports = RandomID(class NonLDSourceForm extends React.Component {
   }
 
   render() {
-    const { onValueChange } = this.props
+    const { onValueChange, sameAs } = this.props
         , value = this.props.value || {}
 
 
@@ -67,7 +67,7 @@ A full citation is encouraged, but a title alone is sufficient.`,
           my: 3,
           name: 'sameAs',
           label: 'Same as (read-only)',
-          value: value.sameAs || '',
+          value: sameAs || '',
           disabled: true,
         }),
 

--- a/modules/periodo-app/src/forms/AuthorityForm/NonLDSourceForm.js
+++ b/modules/periodo-app/src/forms/AuthorityForm/NonLDSourceForm.js
@@ -75,7 +75,7 @@ A full citation is encouraged, but a title alone is sufficient.`,
           my: 3,
           name: 'yearPublished',
           label: 'Year published',
-          value: (value.yearPublished || '').trim(),
+          value: (value.yearPublished || '').toString().trim(),
           onChange: this.handleChange,
         }),
 

--- a/modules/periodo-app/src/forms/AuthorityForm/index.js
+++ b/modules/periodo-app/src/forms/AuthorityForm/index.js
@@ -13,6 +13,7 @@ const h = require('react-hyperscript')
 
 const lenses = {
   source: R.lensProp('source'),
+  sameAs: R.lensProp('sameAs'),
   locator: R.lensPath([ 'source', 'locator' ]),
   editorialNote: R.lensProp('editorialNote'),
 }
@@ -49,6 +50,7 @@ module.exports = Validated(
       const formProps = {
         value: get(lenses.source),
         onValueChange: value => set(lenses.source, value),
+        sameAs: get(lenses.sameAs),
       }
 
       return (

--- a/modules/periodo-app/src/forms/validate.js
+++ b/modules/periodo-app/src/forms/validate.js
@@ -18,6 +18,7 @@ const VALID_AUTHORITY_FIELDS = [
   'source',
   'periods',
   'editorialNote',
+  'sameAs',
 ]
 
 const VALID_AUTHORITY_SOURCE_AGENT_FIELDS = [


### PR DESCRIPTION
Fixes #612 and also an issue which was causing the `sameAs` property of the Heritage Data authority to be lost when editing it.