### PR TITLE
fix: upgrade linkify-it to 5.0.2 (CVE-2026-59887)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "json-stable-stringify": "^1.0.1",
         "jsonld": "^9.0.0",
         "language-tags": "^1.0.5",
-        "linkify-it": "^5.0.0",
+        "linkify-it": "^5.0.2",
         "lov-ns": "^2.0.3",
         "mixmap": "github:periodo/mixmap",
         "n3": "^2.0.0",
@@ -4192,9 +4192,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "json-stable-stringify": "^1.0.1",
     "jsonld": "^9.0.0",
     "language-tags": "^1.0.5",
-    "linkify-it": "^5.0.0",
+    "linkify-it": "^5.0.2",
     "lov-ns": "^2.0.3",
     "mixmap": "github:periodo/mixmap",
     "n3": "^2.0.0",


### PR DESCRIPTION
## Summary
Upgrade linkify-it from 5.0.1 to 5.0.2 to fix CVE-2026-59887.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-59887 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-59887` |
| **File** | `package-lock.json` (dependency: `linkify-it`) |
| **Assessment** | Likely exploitable |

**Description**: linkify-it: Quadratic-complexity DoS via the `mailto:` validator scan-loop on attacker text

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-59887` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
